### PR TITLE
DOT VisualStyle creation updated, arrowshape support revised, node shape support revised

### DIFF
--- a/src/main/java/org/cytoscape/intern/read/DotReaderTask.java
+++ b/src/main/java/org/cytoscape/intern/read/DotReaderTask.java
@@ -44,6 +44,7 @@ import org.cytoscape.model.subnetwork.CySubNetwork;
 import org.cytoscape.view.model.CyNetworkView;
 import org.cytoscape.view.model.CyNetworkViewFactory;
 import org.cytoscape.view.presentation.RenderingEngineManager;
+import org.cytoscape.view.presentation.property.ArrowShapeVisualProperty;
 import org.cytoscape.view.presentation.property.NodeShapeVisualProperty;
 import org.cytoscape.view.vizmap.VisualMappingManager;
 import org.cytoscape.view.vizmap.VisualPropertyDependency;
@@ -64,6 +65,8 @@ import static org.cytoscape.view.presentation.property.BasicVisualLexicon.EDGE_L
 import static org.cytoscape.view.presentation.property.BasicVisualLexicon.EDGE_LABEL_FONT_FACE;
 import static org.cytoscape.view.presentation.property.BasicVisualLexicon.EDGE_LABEL_FONT_SIZE;
 import static org.cytoscape.view.presentation.property.BasicVisualLexicon.EDGE_UNSELECTED_PAINT;
+import static org.cytoscape.view.presentation.property.BasicVisualLexicon.EDGE_TARGET_ARROW_SHAPE;
+import static org.cytoscape.view.presentation.property.BasicVisualLexicon.EDGE_SOURCE_ARROW_SHAPE;
 import static org.cytoscape.view.presentation.property.BasicVisualLexicon.EDGE_STROKE_UNSELECTED_PAINT;
 import static org.cytoscape.view.presentation.property.BasicVisualLexicon.EDGE_WIDTH;
 
@@ -396,6 +399,8 @@ public class DotReaderTask extends AbstractCyNetworkReader {
 		vizStyle.setDefaultValue(EDGE_LABEL_FONT_SIZE, defaultFontSize);
 		vizStyle.setDefaultValue(EDGE_UNSELECTED_PAINT, Color.BLACK);
 		vizStyle.setDefaultValue(EDGE_STROKE_UNSELECTED_PAINT, Color.BLACK);
+		vizStyle.setDefaultValue(EDGE_TARGET_ARROW_SHAPE, ArrowShapeVisualProperty.DELTA);
+		vizStyle.setDefaultValue(EDGE_SOURCE_ARROW_SHAPE, ArrowShapeVisualProperty.DELTA);
 		vizStyle.setDefaultValue(EDGE_WIDTH, 1.0);
 		//Enable "Custom Graphics fit to Node" and "Edge color to arrows" dependency
 		//Also disable "Lock Node height and width"

--- a/src/main/java/org/cytoscape/intern/read/reader/EdgeReader.java
+++ b/src/main/java/org/cytoscape/intern/read/reader/EdgeReader.java
@@ -74,10 +74,13 @@ public class EdgeReader extends Reader{
 	static {
 		ARROW_SHAPE_MAP.put("vee", ArrowShapeVisualProperty.ARROW);
 		ARROW_SHAPE_MAP.put("dot", ArrowShapeVisualProperty.CIRCLE);
+		ARROW_SHAPE_MAP.put("odot", ArrowShapeVisualProperty.CIRCLE);
 		ARROW_SHAPE_MAP.put("normal", ArrowShapeVisualProperty.DELTA);
+		ARROW_SHAPE_MAP.put("onormal", ArrowShapeVisualProperty.DELTA);
 		ARROW_SHAPE_MAP.put("diamond", ArrowShapeVisualProperty.DIAMOND);
-		ARROW_SHAPE_MAP.put("ornormal", ArrowShapeVisualProperty.HALF_BOTTOM);
-		ARROW_SHAPE_MAP.put("olnormal", ArrowShapeVisualProperty.HALF_TOP);
+		ARROW_SHAPE_MAP.put("odiamond", ArrowShapeVisualProperty.DIAMOND);
+		ARROW_SHAPE_MAP.put("rvee", ArrowShapeVisualProperty.HALF_BOTTOM);
+		ARROW_SHAPE_MAP.put("lvee", ArrowShapeVisualProperty.HALF_TOP);
 		ARROW_SHAPE_MAP.put("none", ArrowShapeVisualProperty.NONE);
 		ARROW_SHAPE_MAP.put("tee", ArrowShapeVisualProperty.T);
 	}

--- a/src/main/java/org/cytoscape/intern/read/reader/Reader.java
+++ b/src/main/java/org/cytoscape/intern/read/reader/Reader.java
@@ -133,7 +133,7 @@ public abstract class Reader {
 	 * properties, and EdgeReader sets all edge properties)
 	 */
 	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private void setDefaults() {
+	protected void setDefaults() {
 		LOGGER.info("Setting the Default values for Visual Style...");
 
 		String colorScheme = defaultAttrs.get("colorscheme");
@@ -143,22 +143,6 @@ public abstract class Reader {
 			LOGGER.debug(
 				String.format("Converting DOT attribute: %s", attrKey)
 			);
-
-			/*
-			 * label attribute may be a special case if label="\N".
-			 * In dot, \N is an escape sequence that maps the node name
-			 * to the node label. So setDefaults needs to run additional code
-			 * which should be added to NodeReader to handle the creation of
-			 * the mapping
-			 */
-			/*
-			 * if attrKey is "label"
-
-			 *   call handleLabelDefault()
-			 *   Method will written differently for each subclass
-			 *   NodeReader will create a passthrough mapping if label="\N"
-			 *   Every other subclass will return immediately
-			 */
 
 			Pair<VisualProperty, Object> p = convertAttribute(attrKey, attrVal);
 			// if attribute cannot be converted, move on to next one
@@ -173,7 +157,7 @@ public abstract class Reader {
 				continue;
 			}
 			LOGGER.trace("Updating Visual Style...");
-			LOGGER.debug(String.format("Setting Visual Property %S...", vizProp));
+			LOGGER.debug("Setting Visual Property {} with value {}", vizProp, val);
 			vizStyle.setDefaultValue(vizProp, val);
 		}
 		// Set style attribute here so we handle node shape dependency


### PR DESCRIPTION
Added the default arrow shapes to the VisualStyle created during network
import. Updated arrow shape map so that dot's "lvee" and "rvee" map to
Cytoscapes' HALF_TOP and HALF_BOTTOM respectively, and so "odot",
"onormal", and "odiamond" map to the same arrow shapes as "dot",
"normal", and "diamond" since Cytoscape doesn't support open arrowheads.