### PR TITLE
Change to StringColor and how invalid color strings are handled.

### DIFF
--- a/src/main/java/org/cytoscape/intern/read/reader/EdgeReader.java
+++ b/src/main/java/org/cytoscape/intern/read/reader/EdgeReader.java
@@ -317,16 +317,14 @@ public class EdgeReader extends Reader{
 	protected void setColor(String attrVal,
 			View<? extends CyIdentifiable> elementView, ColorAttribute attr, String colorScheme) {
 
-		LOGGER.trace(
-			String.format(
-				"A color attribute is being applied to edge %s. Color: %s",
-				networkView.getModel().getRow(
-					elementView.getModel()
-				).get(CyNetwork.NAME, String.class),
-				attrVal
-			)
+		LOGGER.trace("A color attribute is being applied to edge {}. Color: {}",
+			networkView.getModel().getRow(elementView.getModel()).get(CyNetwork.NAME, String.class),
+			attrVal
 		);
 		Color color = convertColor(attrVal, colorScheme);
+		if (color == null) {
+			return;
+		}
 		List<Pair<Color, Float>> colorListVals = convertColorList(attrVal, colorScheme);
 		if (colorListVals != null) {
 			color = colorListVals.get(0).getLeft();
@@ -364,13 +362,11 @@ public class EdgeReader extends Reader{
 	protected void setColor(String attrVal, VisualStyle vizStyle,
 			ColorAttribute attr, String colorScheme) {
 	
-		LOGGER.trace(
-			String.format(
-				"A color attribute is being applied to VisualStyle. Color: %s",
-				attrVal
-			)
-		);
+		LOGGER.trace("A color attribute is being applied to VisualStyle. Color: {}", attrVal);
 		Color color = convertColor(attrVal, colorScheme);
+		if (color == null) {
+			return;
+		}
 		List<Pair<Color, Float>> colorListVals = convertColorList(attrVal, colorScheme);
 		if (colorListVals != null) {
 			color = colorListVals.get(0).getLeft();

--- a/src/main/java/org/cytoscape/intern/read/reader/NetworkReader.java
+++ b/src/main/java/org/cytoscape/intern/read/reader/NetworkReader.java
@@ -142,6 +142,9 @@ public class NetworkReader extends Reader {
 	protected void setColor(String attrVal, VisualStyle vizStyle,
 			ColorAttribute attr, String colorScheme) {
 		Color color = convertColor(attrVal, colorScheme);
+		if (color == null) {
+			return;
+		}
 		switch (attr) {
 			case BGCOLOR: {
 				vizStyle.setDefaultValue(NETWORK_BACKGROUND_PAINT, color);

--- a/src/main/java/org/cytoscape/intern/read/reader/NodeReader.java
+++ b/src/main/java/org/cytoscape/intern/read/reader/NodeReader.java
@@ -659,6 +659,9 @@ public class NodeReader extends Reader{
 			View<? extends CyIdentifiable> elementView, ColorAttribute attr, String colorScheme) {
 
 		Color color = convertColor(attrVal, colorScheme);
+		if (color == null) {
+			return;
+		}
 		List<Pair<Color, Float>> colorListValues = convertColorList(attrVal, colorScheme);
 		if (colorListValues != null) {
 			color = colorListValues.get(0).getLeft();
@@ -713,6 +716,9 @@ public class NodeReader extends Reader{
 			ColorAttribute attr, String colorScheme) {
 
 		Color color = convertColor(attrVal, colorScheme);
+		if (color == null) {
+			return;
+		}
 		List<Pair<Color, Float>> colorListValues = convertColorList(attrVal, colorScheme);
 		if (colorListValues != null) {
 			color = colorListValues.get(0).getLeft();

--- a/src/main/java/org/cytoscape/intern/read/reader/Reader.java
+++ b/src/main/java/org/cytoscape/intern/read/reader/Reader.java
@@ -78,12 +78,15 @@ public abstract class Reader {
 
 	// Maps lineStyle attribute values to Cytoscape values
 	protected static final Map<String, LineType> LINE_TYPE_MAP = new HashMap<String, LineType>();
-
 	static {
 		LINE_TYPE_MAP.put("dotted", DOT);
 		LINE_TYPE_MAP.put("dashed", EQUAL_DASH);
 		LINE_TYPE_MAP.put("solid", SOLID);
 	}
+	
+	// Maps string color names to Java Color objects
+	protected static StringColor stringColors;
+
 	// view of network being created/modified
 	protected CyNetworkView networkView;
 	
@@ -107,6 +110,7 @@ public abstract class Reader {
 	 * is null for NetworkReader. Is initialized on Node, Edge Reader
 	 */
 	protected Map<? extends Object, ? extends CyIdentifiable> elementMap;
+	
 
 	/**
 	 * Constructs an object of type Reader.
@@ -230,19 +234,18 @@ public abstract class Reader {
 			Float value = Float.valueOf(matcher.group("VAL"));
 			return Color.getHSBColor(hue, saturation, value);
 		}
+		
 		// String didn't match the regexes, so test if it is a color name
 		// Read in color name files and find it in there
 		LOGGER.trace("Checking if DOT color string is a valid color name");
-		StringColor stringColor = new StringColor("svg_colors.txt", "x11_colors.txt");
-		
-		//String color names are case-insensitive
-		color = color.toLowerCase();
-		Color output = stringColor.getColor(colorScheme, color);
-
+		if (stringColors == null) {
+			stringColors = new StringColor("svg_colors.txt", "x11_colors.txt");
+		}
+		Color output = stringColors.getColor(colorScheme, color);
 		if(output != null) {
 			return output;
 		}
-		// Color was not found. Return a default color
+		// Color was not found
 		LOGGER.info("DOT color string not supported.");
 		return null;
 	}

--- a/src/main/java/org/cytoscape/intern/read/reader/StringColor.java
+++ b/src/main/java/org/cytoscape/intern/read/reader/StringColor.java
@@ -103,7 +103,7 @@ public class StringColor {
 		}
 		
 		Map<String, Color> map = colorMap.get(colorScheme);
-		return map.get(name);
+		return map.get(name.toLowerCase());
 	}
 	
 }


### PR DESCRIPTION
Reader now has a lazy-initialized StringColor object to stop the file
from being read for each graph element that uses color strings. Invalid
color strings immediately exit out the current method so the preexisting
colors are used. Also ensured that string colors were handled in a
case-insensitve fashion